### PR TITLE
Stricter pinning in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,12 @@ webgl = []
 doctest = false
 
 [dependencies]
-bevy = "0.14"
+bevy = "0.14.1"
 parking_lot = ">=0.12.3"
-wgpu = { version = ">=0.20.1", features = ["naga"] }
+wgpu = { version = "0.20.1", features = ["naga"] }
 bytemuck = ">=1.16.1"
-naga = { version = ">=0.20.0", features = ["wgsl-in"] }
-naga_oil = { version = ">=0.14.0", default-features = false, features = [
+naga = { version = "0.20.0", features = ["wgsl-in"] }
+naga_oil = { version = "0.14.0", default-features = false, features = [
     "test_shader",
 ] }
 


### PR DESCRIPTION
Because we rely on a modified `pipeline-cache.rs` copied directly from the Bevy codebase, we need to pin as closely as possible to the `wgpu` and `naga` versions that were used at the time Bevy wrote the `pipeline_cache.rs` file.

It might also be worth using `Cargo.lock`, as that is now recommended for libraries by the Cargo Team: https://blog.rust-lang.org/2023/08/29/committing-lockfiles.html

Longer-term it may even be worth re-architecting the codebase to follow Bevy's [gpu_readback.rs](https://github.com/bevyengine/bevy/blob/main/examples/shader/gpu_readback.rs) example that copies Render World data to the App World using a channel. This would mean we wouldn't even need the `pipeline_cache.rs` file anymore.

Addresses #8